### PR TITLE
Change devicetoken parser

### DIFF
--- a/CanvasCore/CanvasCore/Push Notifications/NotificationKitController.swift
+++ b/CanvasCore/CanvasCore/Push Notifications/NotificationKitController.swift
@@ -19,7 +19,7 @@ import Result
 
 extension String {
     init(deviceToken: Data) {
-        self = deviceToken.reduce("", {$0 + String(format: "%02X", $1)})
+        self = deviceToken.reduce("", {$0 + String(format: "%02.2hhx", $1)})
     }
 }
 


### PR DESCRIPTION
%02X will parsed device token with uppercase. Therefore, it will not matched when compared aws token value and current device token.( when verify token in canvas-lms, notification_endpoint model)